### PR TITLE
minimal changes for new cat.

### DIFF
--- a/xsec_2018_190702.yml
+++ b/xsec_2018_190702.yml
@@ -1,0 +1,404 @@
+'hist_STTH1L3BHct.root':
+  type: signal
+  pretty-name: 'STTH1L3BHct'
+  cross-section: 0.04
+  generated-events: 3016710
+  line-color: '#006666'
+  legend: 'STHct'
+  order: 1
+
+#'hist_TTTH1L3BHct.root':
+#  type: signal
+#  pretty-name: 'TTTH1L3BHct'
+#  cross-section: 1.86
+#  generated-events: 1585684
+#  line-color: '#0000cc'
+#  legend: 'TTHct'
+#  order: 2
+
+'hist_TTTH1L3BaTLepHct.root':
+  type: signal
+  pretty-name: 'TTTH1L3BTLepHct'
+  cross-section: 0.48
+  generated-events: 800715
+  line-color: '#0000cc'
+  legend: 'TTHct'
+  order: 2
+
+'hist_TTTH1L3BTLepHct.root':
+  type: signal
+  pretty-name: 'TTTH1L3BaTLepHct'
+  cross-section: 0.48
+  generated-events: 784969
+  line-color: '#0000cc'
+  legend: 'TTHct'
+  order: 2
+
+###########################
+
+'hist_STTH1L3BHut.root':
+  type: signal
+  pretty-name: 'STTH1L3BHut'
+  cross-section: 0.23
+  generated-events: 3105204
+  line-color: '#666600'
+  legend: 'STHut'
+  order: 3
+
+#'hist_TTTH1L3BHut.root':
+#  type: signal
+#  pretty-name: 'TTTH1L3BHut'
+#  cross-section: 1.86
+#  generated-events: 1569372
+#  line-color: '#cccc00'
+#  legend: 'TTHut'
+#  order: 4
+
+'hist_TTTH1L3BaTLepHut.root':
+  type: signal
+  pretty-name: 'TTTH1L3BaTLepHut'
+  cross-section: 0.385
+  generated-events: 809380
+  line-color: '#cccc00'
+  legend: 'TTHut'
+  order: 4
+
+'hist_TTTH1L3BTLepHut.root':
+  type: signal
+  pretty-name: 'TTTH1L3BTLepHut'
+  cross-section: 0.385
+  generated-events: 759992
+  line-color: '#cccc00'
+  legend: 'TTHut'
+  order: 4
+
+'hist_SingleMuonRun2017.root':
+  type: data
+  legend: 'Data'
+  pretty-name: 'Data'
+  group: GData
+
+'hist_SingleElectronRun2017.root':
+  type: data
+  legend: 'Data'
+  pretty-name: 'Data'
+  group: GData
+
+'hist_TTpowhegttbb.root':
+  type: mc
+  pretty-name: 'TTpowhegttbb'
+  cross-section: 365.34
+  generated-events: 90347648 #100728756
+  fill-color: "#330000"
+  legend: "ttbb"
+  group: Gttbb
+  yields-group: '0\ttbar\bbbar'
+  order: 0
+
+'hist_TTLLpowhegttbb.root':
+  type: mc
+  pretty-name: 'TTLLpowhegttbb'
+  cross-section: 88.29
+  generated-events: 55751966 #100728756
+  fill-color: "#330000"
+  legend: "ttbb"
+  group: Gttbb
+  yields-group: '0\ttbar\bbbar'
+  order: 1
+
+'hist_TTHadpowhegttbb.root':
+  type: mc
+  pretty-name: 'TTHadpowhegttbb'
+  cross-section: 377.96
+  generated-events: 132725582
+  fill-color: "#330000"
+  legend: "ttbb"
+  group: Gttbb
+  yields-group: '0\ttbar\bbbar'
+  order: 2
+
+'hist_TTpowhegttcc.root':
+  type: mc
+  pretty-name: 'TTpowhegttcc'
+  cross-section: 365.34
+  generated-events: 90347648
+  fill-color: '#990000'
+  legend: 'ttcc'
+  group: Gttcc
+  yields-group: '2\ttbar\ccbar'
+  order: 3
+
+'hist_TTLLpowhegttcc.root':
+  type: mc
+  pretty-name: 'TTLLpowhegttcc'
+  cross-section: 88.29
+  generated-events: 55751966
+  fill-color: '#990000'
+  legend: 'ttcc'
+  group: Gttcc
+  yields-group: '2\ttbar\ccbar'
+  order: 4
+
+'hist_TTHadpowhegttcc.root':
+  type: mc
+  pretty-name: 'TTHadpowhegttcc'
+  cross-section: 377.96
+  generated-events: 132725582
+  fill-color: '#990000'
+  legend: 'ttcc'
+  group: Gttcc
+  yields-group: '1\ttbar\ccbar'
+  order: 5
+
+'hist_TTpowhegttlf.root':
+  type: mc
+  pretty-name: 'TTpowhegttlf'
+  cross-section: 365.34
+  generated-events: 90347648
+  fill-color: '#cc0000'
+  legend: 'ttLF'
+  group: Gttlf
+  yields-group: '2\ttbar LF'
+  order: 6
+
+'hist_TTLLpowhegttlf.root':
+  type: mc
+  pretty-name: 'TTLLpowhegttlf'
+  cross-section: 88.29
+  generated-events: 55751966
+  fill-color: '#cc0000'
+  legend: 'ttLF'
+  group: Gttlf
+  yields-group: '2\ttbar LF'
+  order: 7
+
+'hist_TTHadpowhegttlf.root':
+  type: mc
+  pretty-name: 'TTHadpowhegttlf'
+  cross-section: 377.96
+  generated-events: 132725582
+  fill-color: '#cc0000'
+  legend: 'ttLF'
+  group: Gttlf
+  yields-group: '2\ttbar LF'
+  order: 8
+
+'hist_ttHTobb.root':
+  type: mc
+  pretty-name: 'ttHTobb'
+  cross-section: 0.2934
+  generated-events: 11590377
+  fill-color: '#ff66ff'
+  legend: 'ttV/H'
+  group: GttV
+  yields-group: '3Other'
+  order: 9
+
+'hist_ttHToNonbb.root':
+  type: mc
+  pretty-name: 'ttHToNonbb'
+  cross-section: 0.2151
+  generated-events: 7368333
+  fill-color: '#ff66ff'
+  legend: 'ttV/H'
+  group: GttV
+  yields-group: '3Other'
+  order: 10
+
+'hist_TTWJetsToLNu.root':
+  type: mc
+  pretty-name: 'TTWJetsToLNu'
+  cross-section: 0.2043
+  generated-events: 2686095
+  fill-color: '#ff66ff'
+  legend: 'ttV/H'
+  group: GttV
+  yields-group: '3Other'
+  order: 11
+
+'hist_TTWJetsToQQ.root':
+  type: mc
+  pretty-name: 'TTWJetsToQQ'
+  cross-section: 0.4062
+  generated-events: 458226
+  fill-color: '#ff66ff'
+  legend: 'ttV/H'
+  group: GttV
+  yields-group: '3Other'
+  order: 12
+
+'hist_TTZToLLNuNu.root':
+  type: mc
+  pretty-name: 'TTZToLLNuNu'
+  cross-section: 0.2529
+  generated-events: 6274046
+  fill-color: '#ff66ff'
+  legend: 'ttV/H'
+  group: GttV
+  yields-group: '3Other'
+  order: 13
+
+'hist_TTZToQQ.root':
+  type: mc
+  pretty-name: 'TTZToQQ'
+  cross-section: 0.5297
+  generated-events: 355226
+  fill-color: '#ff66ff'
+  legend: 'ttV/H'
+  group: GttV
+  yields-group: '3Other'
+  order: 14
+
+'hist_W1JetsToLNu.root':
+  type: mc
+  pretty-name: 'W1JetsToLNu'
+  cross-section: 9625
+  generated-events: 51047866
+  fill-color: '#ff9933'
+  legend: 'WJets'
+  group: GWJets
+  yields-group: '3Other'
+  order: 25
+
+'hist_W2JetsToLNu.root':
+  type: mc
+  pretty-name: 'W2JetsToLNu'
+  cross-section: 2793
+  generated-events: 23272818
+  fill-color: '#ff9933'
+  legend: 'WJets'
+  group: GWJets
+  yields-group: '3Other'
+  order: 26
+
+'hist_W3JetsToLNu.root':
+  type: mc
+  pretty-name: 'W3JetsToLNu'
+  cross-section: 992.5
+  generated-events: 14492897
+  fill-color: '#ff9933'
+  legend: 'WJets'
+  group: GWJets
+  yields-group: '3Other'
+  order: 27
+
+'hist_W4JetsToLNu.root':
+  type: mc
+  pretty-name: 'W4JetsToLNu'
+  cross-section: 544.3
+  generated-events: 10062333
+  fill-color: '#ff9933'
+  legend: 'WJets'
+  group: GWJets
+  yields-group: '3Other'
+  order: 28
+
+'hist_DYJets.root':
+  type: mc
+  pretty-name: 'DYJets'
+  cross-section: 6225.42
+  generated-events: 100114403
+  fill-color: '#000099'
+  legend: 'ZJets'
+  group: GZJets
+  yields-group: '3Other'
+  order: 23
+
+'hist_DYJets10to50.root':
+  type: mc
+  pretty-name: 'DYJets10to50'
+  cross-section: 18610
+  generated-events: 39360792
+  fill-color: '#000099'
+  legend: 'ZJets'
+  group: GZJets
+  yields-group: '3Other'
+  order: 24
+
+'hist_SingleTops.root':
+  type: mc
+  pretty-name: 'SingleTops'
+  cross-section: 3.36
+  generated-events: 12447484
+  fill-color: '#990099'
+  legend: 'SingleT'
+  group: GSingleT
+  yields-group: '3Other'
+  order: 15
+
+'hist_SingleTopt.root':
+  type: mc
+  pretty-name: 'SingleTopt'
+  cross-section: 136.02
+  generated-events: 144094782
+  fill-color: '#990099'
+  legend: 'SingleT'
+  group: GSingleT
+  yields-group: '3Other'
+  order: 16
+
+'hist_SingleTbart.root':
+  type: mc
+  pretty-name: 'SingleTbart'
+  cross-section: 80.95
+  generated-events: 74227130
+  fill-color: '#990099'
+  legend: 'SingleT'
+  group: GSingleT
+  yields-group: '3Other'
+  order: 17
+
+'hist_SingleToptW.root':
+  type: mc
+  pretty-name: 'SingleToptW'
+  cross-section: 35.85
+  generated-events: 9553912
+  fill-color: '#990099'
+  legend: 'SingleT'
+  group: GSingleT
+  yields-group: '3Other'
+  order: 18
+
+'hist_SingleTbartW.root':
+  type: mc
+  pretty-name: 'SingleTbartW'
+  cross-section: 35.85
+  generated-events: 7588180
+  fill-color: '#990099'
+  legend: 'SingleT'
+  group: GSingleT
+  yields-group: '3Other'
+  order: 19
+
+'hist_WW.root':
+  type: mc
+  pretty-name: 'WW'
+  cross-section: 118.7
+  generated-events: 7850000
+  fill-color: '#00cccc'
+  legend: 'VV'
+  group: GVV
+  yields-group: '3Other'
+  order: 20
+
+'hist_WZ.root':
+  type: mc
+  pretty-name: 'WZ'
+  cross-section: 47.13
+  generated-events: 3885000
+  fill-color: '#00cccc'
+  legend: 'VV'
+  group: GVV
+  yields-group: '3Other'
+  order: 21
+
+'hist_ZZ.root':
+  type: mc
+  pretty-name: 'ZZ'
+  cross-section: 16.523
+  generated-events: 1979000
+  fill-color: '#00cccc'
+  legend: 'VV'
+  group: GVV
+  yields-group: '3Other'
+  order: 22


### PR DESCRIPTION
- rearrange ttbar categoriez
- get systematic names from 'ttlf' root file (not values()[0][0], this may read TT FCNC root file which does not contain top-specific uncertainties)
- 2018 # event yml 
- change file directory (can be ignored, not very important)